### PR TITLE
Make getDataAttributes ignore data attributes which are not in the component's namespace

### DIFF
--- a/integration-tests/default-template/component/src/js/default-template.js
+++ b/integration-tests/default-template/component/src/js/default-template.js
@@ -20,8 +20,8 @@ class DefaultTemplate {
 			return {};
 		}
 		return Object.keys(defaultTemplateEl.dataset).reduce((options, key) => {
-			// Ignore data-o-component
-			if (key === 'oComponent') {
+			// Ignore keys which are not in the component's namespace
+			if (!key.match(/^defaultTemplate(\w)(\w+)$/)) {
 				return options;
 			}
 			// Build a concise key and get the option value


### PR DESCRIPTION
This keeps the method aligned with the definition in the component template https://github.com/Financial-Times/create-origami-component/pull/214